### PR TITLE
draft: jakarta-валидация вместо javax-валидации

### DIFF
--- a/apicross-demoapp/apicross-demoapp-common/pom.xml
+++ b/apicross-demoapp/apicross-demoapp-common/pom.xml
@@ -44,6 +44,7 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
+            <version>${hibernate-validator.version}</version>
             <optional>true</optional>
         </dependency>
 

--- a/apicross-demoapp/apicross-demoapp-common/src/main/java/apicross/demo/common/models/HttpEntityValueExtractor.java
+++ b/apicross-demoapp/apicross-demoapp-common/src/main/java/apicross/demo/common/models/HttpEntityValueExtractor.java
@@ -2,8 +2,8 @@ package apicross.demo.common.models;
 
 import org.springframework.http.HttpEntity;
 
-import javax.validation.valueextraction.ExtractedValue;
-import javax.validation.valueextraction.ValueExtractor;
+import jakarta.validation.valueextraction.ExtractedValue;
+import jakarta.validation.valueextraction.ValueExtractor;
 
 public class HttpEntityValueExtractor implements ValueExtractor<HttpEntity<@ExtractedValue ?>> {
     @Override

--- a/apicross-demoapp/apicross-demoapp-common/src/main/java/apicross/demo/common/utils/ExceptionsHandler.java
+++ b/apicross-demoapp/apicross-demoapp-common/src/main/java/apicross/demo/common/utils/ExceptionsHandler.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.validation.ConstraintViolationException;
+import jakarta.validation.ConstraintViolationException;
 import java.util.Map;
 
 @Slf4j

--- a/apicross-demoapp/apicross-demoapp-common/src/main/java/apicross/demo/common/utils/ValidationErrorsFactory.java
+++ b/apicross-demoapp/apicross-demoapp-common/src/main/java/apicross/demo/common/utils/ValidationErrorsFactory.java
@@ -5,10 +5,10 @@ import io.github.itroadlabs.apicross.beanvalidation.MinProperties;
 import io.github.itroadlabs.apicross.beanvalidation.RequiredProperties;
 import apicross.demo.common.models.QueryObjectMarker;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
-import javax.validation.ElementKind;
-import javax.validation.Path;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import jakarta.validation.ElementKind;
+import jakarta.validation.Path;
 import java.lang.annotation.Annotation;
 import java.util.*;
 

--- a/apicross-demoapp/apicross-demoapp-common/src/main/java/apicross/demo/common/utils/ValidationStages.java
+++ b/apicross-demoapp/apicross-demoapp-common/src/main/java/apicross/demo/common/utils/ValidationStages.java
@@ -2,8 +2,8 @@ package apicross.demo.common.utils;
 
 import io.github.itroadlabs.apicross.beanvalidation.BeanPropertiesValidationGroup;
 
-import javax.validation.GroupSequence;
-import javax.validation.groups.Default;
+import jakarta.validation.GroupSequence;
+import jakarta.validation.groups.Default;
 
 @GroupSequence({BeanPropertiesValidationGroup.class, Default.class})
 public interface ValidationStages {

--- a/apicross-demoapp/apicross-demoapp-myspace-service/pom.xml
+++ b/apicross-demoapp/apicross-demoapp-myspace-service/pom.xml
@@ -49,6 +49,19 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
+            <version>${hibernate-validator.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>3.0.2</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.el</artifactId>
+            <version>4.0.1</version>
         </dependency>
 
         <dependency>

--- a/apicross-demoapp/apicross-demoapp-myspace-service/src/main/java/apicross/demo/myspace/MySpaceMicroserviceConfiguration.java
+++ b/apicross-demoapp/apicross-demoapp-myspace-service/src/main/java/apicross/demo/myspace/MySpaceMicroserviceConfiguration.java
@@ -6,8 +6,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
-import javax.validation.Validation;
-import javax.validation.Validator;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 import java.util.Collections;
 
 @Configuration

--- a/apicross-demoapp/apicross-demoapp-myspace-service/src/main/java/apicross/demo/myspace/app/ManageCompetitionsService.java
+++ b/apicross-demoapp/apicross-demoapp-myspace-service/src/main/java/apicross/demo/myspace/app/ManageCompetitionsService.java
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import java.util.List;
 
 @Service

--- a/apicross-demoapp/apicross-demoapp-myspace-service/src/main/java/apicross/demo/myspace/app/ManageWorksService.java
+++ b/apicross-demoapp/apicross-demoapp-myspace-service/src/main/java/apicross/demo/myspace/app/ManageWorksService.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/apicross-demoapp/apicross-demoapp-myspace-service/src/test/java/apicross/demo/myspace/MySpaceMicroserviceTests.java
+++ b/apicross-demoapp/apicross-demoapp-myspace-service/src/test/java/apicross/demo/myspace/MySpaceMicroserviceTests.java
@@ -12,6 +12,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 import java.time.LocalDate;
@@ -52,6 +53,7 @@ public class MySpaceMicroserviceTests {
                 .andExpect(status().is(401));
     }
 
+    // TODO Этот падает с ошибкой из-за того, что почему-то валидация не происходит
     @Test
     public void creating_competition_invalid_request_body() throws Exception {
         RequestPostProcessor auth = httpBasic("user1", "user1Pass");

--- a/apicross-demoapp/apicross-demoapp-storefront-service/pom.xml
+++ b/apicross-demoapp/apicross-demoapp-storefront-service/pom.xml
@@ -34,6 +34,13 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
+            <version>${hibernate-validator.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>3.0.2</version>
         </dependency>
 
         <dependency>

--- a/apicross-demoapp/apicross-demoapp-storefront-service/src/main/java/apicross/demoapp/storefront/StorefrontMicroserviceConfiguration.java
+++ b/apicross-demoapp/apicross-demoapp-storefront-service/src/main/java/apicross/demoapp/storefront/StorefrontMicroserviceConfiguration.java
@@ -5,8 +5,8 @@ import org.hibernate.validator.resourceloading.AggregateResourceBundleLocator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import javax.validation.Validation;
-import javax.validation.Validator;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 import java.util.Collections;
 
 @Configuration

--- a/apicross-demoapp/apicross-demoapp-storefront-service/src/main/java/apicross/demoapp/storefront/app/StorefrontService.java
+++ b/apicross-demoapp/apicross-demoapp-storefront-service/src/main/java/apicross/demoapp/storefront/app/StorefrontService.java
@@ -9,7 +9,7 @@ import apicross.demoapp.storefront.domain.Competition;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 import java.util.Collections;
 
 @Service

--- a/apicross-demoapp/apicross-demoapp-storefront-service/src/main/java/apicross/demoapp/storefront/app/VotesService.java
+++ b/apicross-demoapp/apicross-demoapp-storefront-service/src/main/java/apicross/demoapp/storefront/app/VotesService.java
@@ -6,7 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
-import javax.validation.Valid;
+import jakarta.validation.Valid;
 
 @Service
 @Validated({ValidationStages.class})

--- a/apicross-demoapp/apicross-demoapp-storefront-service/src/main/resources/apicross/demoapp/storefront/alternative_templates/dataModel.hbs
+++ b/apicross-demoapp/apicross-demoapp-storefront-service/src/main/resources/apicross/demoapp/storefront/alternative_templates/dataModel.hbs
@@ -4,8 +4,8 @@
 package {{package}};
 
 import com.fasterxml.jackson.annotation.*;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import jakarta.validation.constraints.*;
+import jakarta.validation.Valid;
 
 import javax.annotation.*;
 import java.util.*;

--- a/apicross-spring-cloud-openfeign/pom.xml
+++ b/apicross-spring-cloud-openfeign/pom.xml
@@ -59,8 +59,14 @@
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>6.0.18.Final</version>
+            <version>${hibernate-validator.version}</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <version>3.0.2</version>
         </dependency>
 
         <dependency>

--- a/apicross-spring-cloud-openfeign/src/main/resources/io/github/itroadlabs/apicross/springcloudopenfeign/templates/dataModel.hbs
+++ b/apicross-spring-cloud-openfeign/src/main/resources/io/github/itroadlabs/apicross/springcloudopenfeign/templates/dataModel.hbs
@@ -1,8 +1,8 @@
 package {{package}};
 
 import com.fasterxml.jackson.annotation.*;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import jakarta.validation.constraints.*;
+import jakarta.validation.Valid;
 
 import javax.annotation.*;
 import java.util.*;

--- a/apicross-springmvc/src/main/resources/io/github/itroadlabs/apicross/springmvc/templates/dataModel.hbs
+++ b/apicross-springmvc/src/main/resources/io/github/itroadlabs/apicross/springmvc/templates/dataModel.hbs
@@ -1,8 +1,8 @@
 package {{package}};
 
 import com.fasterxml.jackson.annotation.*;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import jakarta.validation.constraints.*;
+import jakarta.validation.Valid;
 
 import javax.annotation.*;
 import java.util.*;

--- a/apicross-springmvc/src/main/resources/io/github/itroadlabs/apicross/springmvc/templates/dataModelReadInterface.hbs
+++ b/apicross-springmvc/src/main/resources/io/github/itroadlabs/apicross/springmvc/templates/dataModelReadInterface.hbs
@@ -1,8 +1,8 @@
 package {{package}};
 
 import com.fasterxml.jackson.annotation.*;
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import jakarta.validation.constraints.*;
+import jakarta.validation.Valid;
 
 import java.util.*;
 import javax.annotation.*;

--- a/apicross-springmvc/src/main/resources/io/github/itroadlabs/apicross/springmvc/templates/requestsHandlerQueryStringParametersObject.hbs
+++ b/apicross-springmvc/src/main/resources/io/github/itroadlabs/apicross/springmvc/templates/requestsHandlerQueryStringParametersObject.hbs
@@ -2,8 +2,8 @@ package {{package}};
 {{#each imports}}
     import {{this}};
 {{/each}}
-import javax.validation.constraints.*;
-import javax.validation.Valid;
+import jakarta.validation.constraints.*;
+import jakarta.validation.Valid;
 import java.util.*;
 import javax.annotation.*;
 {{#if anyOptionalQueryParameter}}

--- a/apicross-toolbox/pom.xml
+++ b/apicross-toolbox/pom.xml
@@ -15,16 +15,15 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-            <version>2.0.1.Final</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
             <version>${hibernate-validator.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.el</artifactId>
+            <version>4.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
@@ -43,13 +42,13 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>${spring-boot.version}</version>
+            <version>2.5.2</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>${spring-boot.version}</version>
+            <version>2.5.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/apicross-toolbox/src/main/java/io/github/itroadlabs/apicross/beanvalidation/MaxProperties.java
+++ b/apicross-toolbox/src/main/java/io/github/itroadlabs/apicross/beanvalidation/MaxProperties.java
@@ -1,7 +1,7 @@
 package io.github.itroadlabs.apicross.beanvalidation;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/apicross-toolbox/src/main/java/io/github/itroadlabs/apicross/beanvalidation/MaxPropertiesValidator.java
+++ b/apicross-toolbox/src/main/java/io/github/itroadlabs/apicross/beanvalidation/MaxPropertiesValidator.java
@@ -2,8 +2,8 @@ package io.github.itroadlabs.apicross.beanvalidation;
 
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 import java.util.HashSet;
 import java.util.Set;
 

--- a/apicross-toolbox/src/main/java/io/github/itroadlabs/apicross/beanvalidation/MinProperties.java
+++ b/apicross-toolbox/src/main/java/io/github/itroadlabs/apicross/beanvalidation/MinProperties.java
@@ -1,7 +1,7 @@
 package io.github.itroadlabs.apicross.beanvalidation;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/apicross-toolbox/src/main/java/io/github/itroadlabs/apicross/beanvalidation/MinPropertiesValidator.java
+++ b/apicross-toolbox/src/main/java/io/github/itroadlabs/apicross/beanvalidation/MinPropertiesValidator.java
@@ -2,8 +2,8 @@ package io.github.itroadlabs.apicross.beanvalidation;
 
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 import java.util.HashSet;
 import java.util.Set;
 

--- a/apicross-toolbox/src/main/java/io/github/itroadlabs/apicross/beanvalidation/RequiredProperties.java
+++ b/apicross-toolbox/src/main/java/io/github/itroadlabs/apicross/beanvalidation/RequiredProperties.java
@@ -1,7 +1,7 @@
 package io.github.itroadlabs.apicross.beanvalidation;
 
-import javax.validation.Constraint;
-import javax.validation.Payload;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/apicross-toolbox/src/main/java/io/github/itroadlabs/apicross/beanvalidation/RequiredPropertiesValidator.java
+++ b/apicross-toolbox/src/main/java/io/github/itroadlabs/apicross/beanvalidation/RequiredPropertiesValidator.java
@@ -2,8 +2,8 @@ package io.github.itroadlabs.apicross.beanvalidation;
 
 import org.hibernate.validator.constraintvalidation.HibernateConstraintValidatorContext;
 
-import javax.validation.ConstraintValidator;
-import javax.validation.ConstraintValidatorContext;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;

--- a/apicross-toolbox/src/test/java/io/github/itroadlabs/apicross/beanvalidation/BeanPropertiesValidationTests.java
+++ b/apicross-toolbox/src/test/java/io/github/itroadlabs/apicross/beanvalidation/BeanPropertiesValidationTests.java
@@ -1,11 +1,11 @@
 package io.github.itroadlabs.apicross.beanvalidation;
 
+import jakarta.validation.ConstraintViolation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.validation.ConstraintViolation;
-import javax.validation.Validation;
-import javax.validation.Validator;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <spring-boot.version>2.4.0</spring-boot.version>
         <spring-cloud.version>2.2.1.RELEASE</spring-cloud.version>
         <spring.version>5.2.4.RELEASE</spring.version>
-        <hibernate-validator.version>6.0.18.Final</hibernate-validator.version>
+        <hibernate-validator.version>7.0.5.Final</hibernate-validator.version>
         <jupiter.version>5.7.1</jupiter.version>
         <jupoter.platform.version>1.7.1</jupoter.platform.version>
         <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
@@ -158,6 +158,20 @@
                 <version>2.2</version>
                 <scope>test</scope>
             </dependency>
+
+            <dependency>
+                <groupId>org.hibernate.validator</groupId>
+                <artifactId>hibernate-validator</artifactId>
+                <version>${hibernate-validator.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.validation</groupId>
+                <artifactId>jakarta.validation-api</artifactId>
+                <version>3.0.2</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Использование jakarta-валидации вместо javax-валидации.
В демо-приложении `apicross-demoapp-myspace-service` падает тест `creating_competition_invalid_request_body` - почему-то не происходит валидация.